### PR TITLE
Fix gitops_agent_yaml_file encoding

### DIFF
--- a/agent.tf
+++ b/agent.tf
@@ -21,7 +21,7 @@ data "harness_platform_gitops_agent_deploy_yaml" "gitops_agent_yaml" {
 
 resource "local_file" "gitops_agent_yaml_file" {
   filename = "gitops_agent.yaml"
-  content  = data.harness_platform_gitops_agent_deploy_yaml.gitops_agent_yaml.yaml
+  content  = jsondecode(data.harness_platform_gitops_agent_deploy_yaml.gitops_agent_yaml.yaml).value
 }
 
 resource "null_resource" "deploy_agent_resources_to_cluster" {


### PR DESCRIPTION
Currently a json object is written to the gitops_agent.yaml file, with a single property called "value". This PR decodes the json object and uses the "value" property to ensure the gitops_agent.yaml file contains only the yaml manifests required.